### PR TITLE
improve selected card visibility

### DIFF
--- a/src/GameBoard/GameCard.jsx
+++ b/src/GameBoard/GameCard.jsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
   }),
   selected: {
     borderColor: theme.palette.primary.main,
+    outline: `2px solid ${theme.palette.primary.main}`,
   },
   spare: {
     flexBasis: null,


### PR DESCRIPTION
Resolves #3.

Add extra border around the selected card to improve visibility. I couldn't get the backend and frontend to talk via websocket in order to test this, but I believe this change should do the trick.