### PR TITLE
Put spare card closer to the board and some graphics fixes

### DIFF
--- a/src/GameBoard/GameBoard.jsx
+++ b/src/GameBoard/GameBoard.jsx
@@ -43,7 +43,7 @@ function GameBoard({
       setMinimizedGameOver(false);
     }
   }, [winner, setMinimizedGameOver]);
-  const hideSideSpare = useMediaQuery(theme.breakpoints.down('sm'));
+  const hideSideSpare = useMediaQuery(theme.breakpoints.down('xs'));
   // Whether it's the player's turn, always true if local multiplayer
   const playerTurn = player ? player === turn : true;
   // Whether perspective should have red at bottom of screen
@@ -53,7 +53,11 @@ function GameBoard({
       <Box display="flex" justifyContent="center">
         <GameTurn player={player} turn={turn} />
       </Box>
-      <Box display="flex" flexDirection={redOriented ? 'row' : 'row-reverse'}>
+      <Box
+        display="flex"
+        flexDirection={redOriented ? 'row' : 'row-reverse'}
+        style={{ gap: '16px' }}
+      >
         <Box position="absolute" top="0" left="0">
           <Button component={Link} to="/">
             Home
@@ -67,26 +71,35 @@ function GameBoard({
           minimizedGameOver={minimizedGameOver}
           setMinimizedGameOver={setMinimizedGameOver}
         />
+        {!hideSideSpare && (
+          <Box
+            display={hideSideSpare ? 'none' : 'flex'}
+            flexDirection="column"
+            justifyContent="center"
+            alignItems={redOriented ? 'flex-end' : 'flex-start'}
+            flexGrow={1}
+            flexBasis={0}
+          >
+            {turn === 'Blue' && (
+              <GameCard
+                spare
+                inverted={redOriented}
+                moves={spare.moves}
+                enabled={false}
+                setCard={setCard}
+                name={spare.card}
+                selected={false}
+              />
+            )}
+          </Box>
+        )}
         <Box
-          display={hideSideSpare ? 'none' : 'flex'}
-          flexDirection="column"
+          display="flex"
           justifyContent="center"
           alignItems="center"
-          flexBasis="33%"
+          flexGrow={hideSideSpare ? 1 : 0}
+          flexShrink={0}
         >
-          {turn === 'Blue' && (
-            <GameCard
-              spare
-              inverted={redOriented}
-              moves={spare.moves}
-              enabled={false}
-              setCard={setCard}
-              name={spare.card}
-              selected={false}
-            />
-          )}
-        </Box>
-        <Box display="flex" justifyContent="center" alignItems="center" flexGrow={1}>
           <Box display="flex" flexDirection={redOriented ? 'column' : 'column-reverse'}>
             <GameHand
               setCard={setCard}
@@ -124,25 +137,28 @@ function GameBoard({
           </Box>
           <GameScore score={score} stale={stale} playerIsRed={player === 'Red'} />
         </Box>
-        <Box
-          display={hideSideSpare ? 'none' : 'flex'}
-          flexDirection="column"
-          justifyContent="center"
-          alignItems="center"
-          flexBasis="33%"
-        >
-          {turn === 'Red' && (
-            <GameCard
-              spare
-              inverted={!redOriented}
-              moves={spare.moves}
-              enabled={false}
-              setCard={setCard}
-              name={spare.card}
-              selected={false}
-            />
-          )}
-        </Box>
+        {!hideSideSpare && (
+          <Box
+            display={hideSideSpare ? 'none' : 'flex'}
+            flexDirection="column"
+            justifyContent="center"
+            alignItems={redOriented ? 'flex-start' : 'flex-end'}
+            flexGrow={1}
+            flexBasis={0}
+          >
+            {turn === 'Red' && (
+              <GameCard
+                spare
+                inverted={!redOriented}
+                moves={spare.moves}
+                enabled={false}
+                setCard={setCard}
+                name={spare.card}
+                selected={false}
+              />
+            )}
+          </Box>
+        )}
       </Box>
       {undo && (
         <Box width="100%" display="flex" justifyContent="center" py={2}>

--- a/src/GameBoard/GameHand.jsx
+++ b/src/GameBoard/GameHand.jsx
@@ -15,7 +15,7 @@ function GameHand({
   inverted,
 }) {
   const theme = useTheme();
-  const showSpare = useMediaQuery(theme.breakpoints.down('sm')) && !isPlayerTurn;
+  const showSpare = useMediaQuery(theme.breakpoints.down('xs')) && !isPlayerTurn;
   return (
     <Box display="flex" flexDirection={inverted ? 'row-reverse' : 'row'} style={{ gap: '8px' }}>
       {showSpare && (


### PR DESCRIPTION
* Put spare card closer to the board (fixes https://github.com/jackadamson/onitama/issues/11)
* Slightly reduce the "hide-spare" breakpoint because the spare card can be way closer to the board than before

Before:
![Screenshot_42](https://user-images.githubusercontent.com/3482407/191665732-76fcbf58-0157-4312-9fd5-a7c1ac9b05e1.png)

Now:
![Screenshot_43](https://user-images.githubusercontent.com/3482407/191665730-51f407dd-54e1-4fda-8984-1d67928b5a92.png)

Collapsed:
![Screenshot_44](https://user-images.githubusercontent.com/3482407/191665728-b5b39b7c-5b8f-4b71-bdb0-f350eec3e357.png)