### PR TITLE
Add Wind Spirit card normal moves

### DIFF
--- a/onitamalib/src/board.rs
+++ b/onitamalib/src/board.rs
@@ -6,9 +6,10 @@ use crate::models::{Board, Card, GameSquare, GameState, Move, Player, Point};
 
 impl Board {
     pub fn try_move(self: &Board, game_move: Move) -> Result<GameState, String> {
-        let (blue_king, blue_pawns, blue_hand, red_king, red_pawns, red_hand, spare_card, turn) =
+        let (wind_spirit, blue_king, blue_pawns, blue_hand, red_king, red_pawns, red_hand, spare_card, turn) =
             match self {
                 Board {
+                    wind_spirit,
                     blue_king,
                     blue_pawns,
                     blue_hand,
@@ -18,7 +19,7 @@ impl Board {
                     spare_card,
                     turn,
                 } => (
-                    blue_king, blue_pawns, blue_hand, red_king, red_pawns, red_hand, spare_card,
+                    wind_spirit, blue_king, blue_pawns, blue_hand, red_king, red_pawns, red_hand, spare_card,
                     turn,
                 ),
             };
@@ -43,6 +44,7 @@ impl Board {
                 };
                 return Ok(GameState::Playing {
                     board: Board {
+                        wind_spirit: *wind_spirit,
                         blue_king: *blue_king,
                         blue_pawns: *blue_pawns,
                         blue_hand,
@@ -55,6 +57,7 @@ impl Board {
                 });
             }
         };
+
         if !self.player_hand().contains(&card) {
             return Err("Card not in hand".to_string());
         }
@@ -102,6 +105,7 @@ impl Board {
         };
         let board = match self.turn {
             Player::Red => Board {
+                wind_spirit: *wind_spirit,
                 blue_king: *blue_king,
                 blue_pawns: opponent_pawns,
                 blue_hand: *blue_hand,
@@ -112,6 +116,7 @@ impl Board {
                 turn: Player::Blue,
             },
             Player::Blue => Board {
+                wind_spirit: *wind_spirit,
                 blue_king: player_king,
                 blue_pawns: player_pawns,
                 blue_hand: player_hand,
@@ -140,6 +145,7 @@ impl Board {
         let mut cards = cards.into_iter();
         let pawn_xs: [i8; 4] = [0, 1, 3, 4];
         Board {
+            wind_spirit: Point {x: 2, y: 2 },
             blue_king: Point { x: 2, y: 0 },
             blue_pawns: pawn_xs.map(|x| Some(Point { x, y: 0 })),
 
@@ -179,6 +185,8 @@ impl Board {
         for Point { x, y } in self.red_pawns.iter().filter_map(|p| *p) {
             grid[y as usize][x as usize] = GameSquare::RedPawn;
         }
+        let Point { x, y } = self.wind_spirit;
+        grid[y as usize][x as usize] = GameSquare::WindSpirit;
         let Point { x, y } = self.red_king;
         grid[y as usize][x as usize] = GameSquare::RedKing;
         let Point { x, y } = self.blue_king;
@@ -249,6 +257,15 @@ impl Board {
 }
 
 impl Board {
+    pub fn wind_spirit(&self) -> &Point {
+        match self.turn {
+            Player::Red => &self.wind_spirit,
+            Player::Blue => &Point {x: 0, y: 0},
+        }
+    }
+}
+
+impl Board {
     pub fn player_king(&self) -> &Point {
         match self.turn {
             Player::Red => &self.red_king,
@@ -264,16 +281,18 @@ impl Board {
 }
 
 impl Board {
-    pub fn player_pieces(&self) -> [Option<Point>; 5] {
-        let mut pieces: [Option<Point>; 5] = [None; 5];
-        pieces[1..].copy_from_slice(&*self.player_pawns());
+    pub fn player_pieces(&self) -> [Option<Point>; 6] {
+        let mut pieces: [Option<Point>; 6] = [None; 6];
         pieces[0] = Some(*self.player_king());
+        pieces[1] = Some(*self.wind_spirit());
+        pieces[2..].copy_from_slice(&*self.player_pawns());
         return pieces;
     }
-    pub fn opponent_pieces(&self) -> [Option<Point>; 5] {
-        let mut pieces: [Option<Point>; 5] = [None; 5];
-        pieces[1..].copy_from_slice(&*self.opponent_pawns());
+    pub fn opponent_pieces(&self) -> [Option<Point>; 6] {
+        let mut pieces: [Option<Point>; 6] = [None; 6];
         pieces[0] = Some(*self.opponent_king());
+        pieces[1] = Some(*self.wind_spirit());
+        pieces[2..].copy_from_slice(&*self.opponent_pawns());
         return pieces;
     }
 }

--- a/onitamalib/src/cards.rs
+++ b/onitamalib/src/cards.rs
@@ -232,6 +232,40 @@ impl Card {
                 Point { x: 2, y: 1 },
                 Point { x: 0, y: -1 },
             ],
+            // Wind Spirit Cards
+            Card::Bat => vec![
+                Point { x: 0, y: 1 },
+                Point { x: 0, y: -1 },
+            ],
+            Card::Eagle => vec![
+                Point { x: -1, y: -1 },
+                Point { x: 1, y: -1 },
+            ],
+            Card::Hawk => vec![
+                Point { x: -1, y: -1 },
+                Point { x: -1, y: 1 },
+            ],
+            Card::Lion => vec![
+                Point { x: -1, y: 1 },
+                Point { x: 1, y: -1 },
+            ],
+            Card::Octopus => vec![
+                Point { x: -1, y: -1 },
+                Point { x: 1, y: 1 },
+            ],
+            Card::Rhinoceros => vec![
+                Point { x: -1, y: -1 },
+                Point { x: 0, y: 1 },
+            ],
+            Card::Scorpion => vec![
+                Point { x: 1, y: 1 },
+                Point { x: 1, y: -1 },
+            ],
+            Card::Spider => vec![
+                Point { x: 1, y: -1 },
+                Point { x: 0, y: 1 },
+            ],
+
         }
     }
     pub fn direction(&self) -> CardDirection {
@@ -282,6 +316,15 @@ impl Card {
             Card::Nessie => CardDirection::Balanced,
             Card::Butterfly => CardDirection::Balanced,
             Card::Moth => CardDirection::Balanced,
+            // Wind Spirit Cards
+            Card::Bat => CardDirection::Balanced,
+            Card::Eagle => CardDirection::Balanced,
+            Card::Hawk => CardDirection::Left,
+            Card::Lion => CardDirection::Right,
+            Card::Octopus => CardDirection::Left,
+            Card::Rhinoceros => CardDirection::Left,
+            Card::Scorpion => CardDirection::Right,
+            Card::Spider => CardDirection::Right,
         }
     }
     pub fn index(&self) -> u32 {
@@ -331,6 +374,15 @@ impl Card {
             Card::Nessie => 40,
             Card::Butterfly => 41,
             Card::Moth => 42,
+            // Wind Spirit Cards
+            Card::Bat => 43,
+            Card::Eagle => 44,
+            Card::Hawk => 45,
+            Card::Lion => 46,
+            Card::Octopus => 47,
+            Card::Rhinoceros => 48,
+            Card::Scorpion => 49,
+            Card::Spider => 50,
         }
     }
 }
@@ -383,6 +435,15 @@ impl From<u32> for Card {
             40 => Card::Nessie,
             41 => Card::Butterfly,
             42 => Card::Moth,
+            // Wind Spirit Cards
+            43 => Card::Bat,
+            44 => Card::Eagle,
+            45 => Card::Hawk,
+            46 => Card::Lion,
+            47 => Card::Octopus,
+            48 => Card::Rhinoceros,
+            49 => Card::Scorpion,
+            50 => Card::Spider,
             _ => panic!("invalid index for card"),
         }
     }
@@ -440,7 +501,16 @@ impl CardSet {
                 Card::Butterfly,
                 Card::Moth,
             ],
-            
+            CardSet::WayOfTheWind => vec![
+                Card::Bat,
+                Card::Eagle,
+                Card::Hawk,
+                Card::Lion,
+                Card::Octopus,
+                Card::Rhinoceros,
+                Card::Scorpion,
+                Card::Spider,
+            ]
         }
     }
 }

--- a/onitamalib/src/models.rs
+++ b/onitamalib/src/models.rs
@@ -194,6 +194,7 @@ impl From<CardSet> for CardSetDescription {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Board {
+    pub wind_spirit: Point,
     pub blue_king: Point,
     pub blue_pawns: [Option<Point>; 4],
     pub blue_hand: [Card; 2],
@@ -220,6 +221,7 @@ pub enum GameState {
 
 #[derive(Copy, Clone, Serialize, Deserialize, Debug)]
 pub enum GameSquare {
+    WindSpirit,
     RedKing,
     RedPawn,
     BlueKing,

--- a/onitamalib/src/models.rs
+++ b/onitamalib/src/models.rs
@@ -134,6 +134,15 @@ pub enum Card {
     Nessie,
     Butterfly,
     Moth,
+    // Wind Spirit Cards
+    Bat,
+    Eagle,
+    Hawk,
+    Lion,
+    Octopus,
+    Rhinoceros,
+    Scorpion,
+    Spider,
 }
 
 impl fmt::Display for Card {
@@ -147,6 +156,7 @@ pub enum CardSet {
     Base,
     SenseiPath,
     PromotionalPack,
+    WayOfTheWind,
 }
 
 impl ToString for CardSet {
@@ -155,6 +165,7 @@ impl ToString for CardSet {
             CardSet::Base => "Base Game".to_string(),
             CardSet::SenseiPath => "Sensei's Path".to_string(),
             CardSet::PromotionalPack => "Promotional Cards".to_string(),
+            CardSet::WayOfTheWind => "Way of the Wind".to_string(),
         }
     }
 }

--- a/onitamalib/src/tests/utils.rs
+++ b/onitamalib/src/tests/utils.rs
@@ -34,6 +34,7 @@ impl Board {
         let mut cards = cards.into_iter();
         let pawn_xs: [i8; 4] = [0, 1, 3, 4];
         Board {
+            wind_spirit: Point { x: 2, y: 2 },
             blue_king: Point { x: 2, y: 0 },
             blue_pawns: pawn_xs.map(|x| Some(Point { x, y: 0 })),
 

--- a/src/GameBoard/GameSquare.jsx
+++ b/src/GameBoard/GameSquare.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { Box, makeStyles, Paper, Tooltip } from '@material-ui/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChessPawn, faChessKing, faSkull, faStar } from '@fortawesome/free-solid-svg-icons';
+import { faChessPawn, faChessKing, faChessQueen, faSkull, faStar } from '@fortawesome/free-solid-svg-icons';
 import Color from 'color';
 import { PointPropType } from './props';
 
 const icons = {
   Empty: null,
+  WindSpirit: <FontAwesomeIcon icon={faChessQueen} color="#B5B4B4" size="3x" />,
   BluePawn: <FontAwesomeIcon icon={faChessPawn} color="#2196f3" size="3x" />,
   BlueKing: <FontAwesomeIcon icon={faChessKing} color="#2196f3" size="3x" />,
   RedPawn: <FontAwesomeIcon icon={faChessPawn} color="#f44336" size="3x" />,


### PR DESCRIPTION
This PR adds the Way of the Wind card pack and the normal move half of the Wind Spirit cards as progress towards #16 

I didn't implement the Wind Spirit moves on these cards as that will depend on how we implement the Wind Spirit itself. 

Just to be clear, this is not intended to be deployed, just work to help implement the Way of the Wind expansion. 

**Closing this while I finish full Wind Spirit implementation.** 